### PR TITLE
hash routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+## 0.7.0
+
+components.dart:
+* **Breaking changes**
+* History is now an interface and is implemented by PushHistory and HashHistory. HashHistory plays nice with the webdev pub package and github pages.
+
+functional.dart:
+
+* **Breaking changes**:
+  * withState now takes named parameters
+
 ## 0.6.0
 repo:
 * use build_runner test in travis

--- a/example/docs/lib/src/components/container.dart
+++ b/example/docs/lib/src/components/container.dart
@@ -9,6 +9,7 @@ import 'panel.dart';
 class Container extends NComponent {
   @override
   VNode render() => HistoryProvider(
+        history: HashHistory(),
         child: VDivElement()
           ..children = [
             Nav(NavProps()),

--- a/example/docs/lib/src/demo_code_strings/demo_code_strings.dart
+++ b/example/docs/lib/src/demo_code_strings/demo_code_strings.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: constant_identifier_names
 
-const version = '0.6.0';
+const version = '0.7.0';
 
 const keys = r'''
 import 'dart:html';

--- a/example/todos_functional_components/lib/src/container.dart
+++ b/example/todos_functional_components/lib/src/container.dart
@@ -12,6 +12,10 @@ typedef void PutAfter(int before, int after);
 
 class ContainerProps {
   Iterable<Todo> todos;
+  ContainerActions actions;
+}
+
+class ContainerActions {
   AddTodo addTodo;
   UpdateTodo updateTodo;
   PutAfter putAfter;
@@ -20,10 +24,16 @@ class ContainerProps {
 ContainerProps stateMapper(
   Null _,
   Iterable<Todo> state,
+  ContainerActions setState,
+) =>
+    ContainerProps()
+      ..todos = state
+      ..actions = setState;
+
+ContainerActions stateSetterFactory(
   SetState<Null, Iterable<Todo>> setState,
 ) =>
-    new ContainerProps()
-      ..todos = state
+    ContainerActions()
       ..addTodo = ((todo) {
         setState((_, prev) => prev.toList()..add(todo));
       })
@@ -46,8 +56,12 @@ ContainerProps stateMapper(
       });
 
 FunctionalComponent<Null> container =
-    withState<Null, Iterable<Todo>, ContainerProps>(
-        [], UpdateKind.syncronous, stateMapper)(_container);
+    withState<Null, Iterable<Todo>, ContainerActions, ContainerProps>(
+  defaultState: [],
+  mapper: stateMapper,
+  stateSetterFactory: stateSetterFactory,
+  updateKind: UpdateKind.syncronous,
+)(_container);
 
 VNode _container(ContainerProps props) => new VDivElement()
   ..children = [
@@ -55,7 +69,7 @@ VNode _container(ContainerProps props) => new VDivElement()
       ..remaining = props.todos.where((t) => !t.isComplete).length),
     content(new ContentProps()
       ..todos = props.todos
-      ..addTodo = props.addTodo
-      ..updateTodo = props.updateTodo
-      ..putAfter = props.putAfter),
+      ..addTodo = props.actions.addTodo
+      ..updateTodo = props.actions.updateTodo
+      ..putAfter = props.actions.putAfter),
   ];

--- a/lib/src/functional/with_state.dart
+++ b/lib/src/functional/with_state.dart
@@ -2,38 +2,48 @@ import '../../wui_builder.dart';
 import 'functional.dart';
 
 typedef void SetState<P, S>(StateSetter<P, S> newState);
-
-typedef OutterP StateMapper<InnerP, S, OutterP>(
+typedef SS StateSetterFactory<InnerP, S, SS>(SetState<InnerP, S> setState);
+typedef OutterP StateMapper<InnerP, S, SS, OutterP>(
   InnerP props,
   S state,
-  SetState<InnerP, S> setState,
+  SS stateSetters,
 );
 
 enum UpdateKind { syncronous, idleCallback, animationFrame }
 
 /// [withState] will let you map your props, given the recieved props,
 /// the state, and a state setter that executes with the update type specified
-ComponentEnhancer<InnerP, OutterP> withState<InnerP, S, OutterP>(S defaultState,
-        UpdateKind updateKind, StateMapper<InnerP, S, OutterP> mapper) =>
+ComponentEnhancer<InnerP, OutterP> withState<InnerP, S, SS, OutterP>({
+  S defaultState,
+  StateSetterFactory<InnerP, S, SS> stateSetterFactory,
+  StateMapper<InnerP, S, SS, OutterP> mapper,
+  UpdateKind updateKind: UpdateKind.animationFrame,
+}) =>
     (baseComponent) =>
-        (props) => new _WithState<InnerP, S, OutterP>(new _WithStateProps()
+        (props) => new _WithState<InnerP, S, SS, OutterP>(new _WithStateProps()
           ..defaultState = defaultState
           ..mapper = mapper
+          ..stateSetterFactory = stateSetterFactory
           ..baseProps = props
           ..updateKind = updateKind
           ..baseComponent = baseComponent);
 
-class _WithStateProps<InnerP, S, OutterP> {
+class _WithStateProps<InnerP, S, SS, OutterP> {
   S defaultState;
-  StateMapper<InnerP, S, OutterP> mapper;
+  StateMapper<InnerP, S, SS, OutterP> mapper;
   InnerP baseProps;
   UpdateKind updateKind;
   FunctionalComponent<OutterP> baseComponent;
+  StateSetterFactory<InnerP, S, SS> stateSetterFactory;
 }
 
-class _WithState<InnerP, S, OutterP>
-    extends Component<_WithStateProps<InnerP, S, OutterP>, S> {
-  _WithState(_WithStateProps<InnerP, S, OutterP> props) : super(props);
+class _WithState<InnerP, S, SS, OutterP>
+    extends Component<_WithStateProps<InnerP, S, SS, OutterP>, S> {
+  SS _stateSetters;
+
+  _WithState(_WithStateProps<InnerP, S, SS, OutterP> props) : super(props) {
+    _stateSetters = props.stateSetterFactory(_setStateSwitch());
+  }
 
   @override
   S getInitialState() => props.defaultState;
@@ -50,24 +60,25 @@ class _WithState<InnerP, S, OutterP>
     setStateOnAnimationFrame((sprops, state) => s(props.baseProps, state));
   }
 
-  void _setStateSwitch(StateSetter<InnerP, S> s) {
+  SetState<InnerP, S> _setStateSwitch() {
     switch (props.updateKind) {
       case UpdateKind.syncronous:
-        _setState(s);
+        return _setState;
         break;
       case UpdateKind.idleCallback:
-        _setStateOnIdle(s);
+        return _setStateOnIdle;
         break;
       case UpdateKind.animationFrame:
-        _setStateOnAnimationFrame(s);
+        return _setStateOnAnimationFrame;
         break;
     }
+    throw Exception('invalid update kind');
   }
 
   @override
   VNode render() => props.baseComponent(props.mapper(
         props.baseProps,
         state,
-        _setStateSwitch,
+        _stateSetters,
       ));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: wui_builder
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/davidmarne/wui_builder
 author: David Marne <davemarne@gmail.com>
 description: A ui framework for dart web apps that leverages a virtual dom.


### PR DESCRIPTION
components.dart:
* **Breaking changes**
* History is now an interface and is implemented by PushHistory and HashHistory. HashHistory plays nice with the webdev pub package and github pages.

functional.dart:

* **Breaking changes**:
  * withState now takes named parameters